### PR TITLE
Fix postgresql 14/stable release

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -61,6 +61,7 @@ class RangerK8SCharm(ops.CharmBase):
             self,
             relation_name="database",
             database_name=PostgresRelationHandler.DB_NAME,
+            extra_user_roles="admin",
         )
         self.postgres_relation_handler = PostgresRelationHandler(self)
         self.provider = RangerProvider(self)


### PR DESCRIPTION
Quick fix due to new release to the postgresql-k8s 14/stable channel today requiring this permission to connect to the postgresql database. This is causing current integration tests to fail.