### PR TITLE
  CSS-9168 Add resource lookup timeout as variable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -116,3 +116,9 @@ options:
       The function the charm should provide, either `admin` or `usersync`.
     type: string
     default: admin
+  lookup-timeout:
+    description: |
+      The default timeout for the resource auto-complete
+      functionality for Ranger service in ms.
+    type: int
+    default: 3000

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 36
+LIBPATCH = 37
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -656,6 +656,10 @@ class CachedSecret:
     def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
         if not self.meta:
+            return
+
+        # DPE-4182: do not create new revision if the content stay the same
+        if content == self.get_content():
             return
 
         if content:

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 35
+LIBPATCH = 36
 
 logger = logging.getLogger(__name__)
 
@@ -1050,6 +1050,7 @@ class GrafanaDashboardProvider(Object):
 
         self.framework.observe(self._charm.on.leader_elected, self._update_all_dashboards_from_dir)
         self.framework.observe(self._charm.on.upgrade_charm, self._update_all_dashboards_from_dir)
+        self.framework.observe(self._charm.on.config_changed, self._update_all_dashboards_from_dir)
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -16,9 +16,10 @@ The provider side of the relation represents the server side, to which logs are 
   applications such as pebble, or charmed operators of workloads such as grafana-agent or promtail,
   that can communicate with loki directly.
 
-- `LogProxyConsumer`: This object can be used by any Charmed Operator which needs to
-send telemetry, such as logs, to Loki through a Log Proxy by implementing the consumer side of the
-`loki_push_api` relation interface.
+- `LogProxyConsumer`: DEPRECATED.
+This object can be used by any Charmed Operator which needs to send telemetry, such as logs, to
+Loki through a Log Proxy by implementing the consumer side of the `loki_push_api` relation
+interface.
 
 Filtering logs in Loki is largely performed on the basis of labels. In the Juju ecosystem, Juju
 topology labels are used to uniquely identify the workload which generates telemetry like logs.
@@ -38,13 +39,14 @@ and three optional arguments.
 - `charm`: A reference to the parent (Loki) charm.
 
 - `relation_name`: The name of the relation that the charm uses to interact
-  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`.
+  with its clients, which implement `LokiPushApiConsumer` or `LogProxyConsumer`
+  (note that LogProxyConsumer is deprecated).
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `loki_push_api` interface.
 
   The default relation name is "logging" for `LokiPushApiConsumer` and "log-proxy" for
-  `LogProxyConsumer`.
+  `LogProxyConsumer` (note that LogProxyConsumer is deprecated).
 
   For example, a provider's `metadata.yaml` file may look as follows:
 
@@ -218,6 +220,9 @@ labels in charm code. See :func:`LogProxyConsumer._scrape_configs` for an exampl
 to do this with promtail.
 
 ## LogProxyConsumer Library Usage
+
+> Note: This object is deprecated. Consider migrating to LogForwarder (see v1/loki_push_api) with
+> the release of Juju 3.6 LTS.
 
 Let's say that we have a workload charm that produces logs, and we need to send those logs to a
 workload implementing the `loki_push_api` interface, such as `Loki` or `Grafana Agent`.
@@ -480,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 29
+LIBPATCH = 30
 
 PYDEPS = ["cosl"]
 
@@ -1539,7 +1544,8 @@ class LokiPushApiConsumer(ConsumerBase):
         the Loki API endpoint to push logs. It is intended for workloads that can speak
         loki_push_api (https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki), such
         as grafana-agent.
-        (If you only need to forward a few workload log files, then use LogProxyConsumer.)
+        (If you need to forward workload stdout logs, then use v1/loki_push_api.LogForwarder; if
+        you need to forward log files, then use LogProxyConsumer.)
 
         `LokiPushApiConsumer` can be instantiated as follows:
 
@@ -1727,6 +1733,9 @@ class LogProxyEvents(ObjectEvents):
 
 class LogProxyConsumer(ConsumerBase):
     """LogProxyConsumer class.
+
+    > Note: This object is deprecated. Consider migrating to v1/loki_push_api.LogForwarder with the
+    > release of Juju 3.6 LTS.
 
     The `LogProxyConsumer` object provides a method for attaching `promtail` to
     a workload in order to generate structured logging data from applications

--- a/src/relations/provider.py
+++ b/src/relations/provider.py
@@ -144,6 +144,9 @@ class RangerProvider(Object):
         )
         service.configs = {
             "username": f"relation_id_{event.relation.id}",
+            "resource.lookup.timeout.value.in.ms": self.charm.config[
+                "lookup-timeout"
+            ],
         }
         for key, value in data.items():
             if key not in ["name", "type"]:

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -60,6 +60,7 @@ class CharmConfig(BaseConfigModel):
     ranger_usersync_password: Optional[str]
     policy_mgr_url: str
     charm_function: FunctionType
+    lookup_timeout: int
 
     @validator("*", pre=True)
     @classmethod
@@ -113,3 +114,22 @@ class CharmConfig(BaseConfigModel):
         if re.match(ldap_url_pattern, value) is not None:
             return value
         raise ValueError("Value incorrectly formatted.")
+
+    @validator("lookup_timeout")
+    @classmethod
+    def lookup_timeout_validator(cls, value: str) -> Optional[int]:
+        """Check validity of `lookup_timeout` field.
+
+        Args:
+            value: timeout value
+
+        Returns:
+            int_value: integer for service configuration
+
+        Raises:
+            ValueError: in the case when the value is out of range
+        """
+        int_value = int(value)
+        if 1000 <= int_value <= 10000:
+            return int_value
+        raise ValueError("Value out of range.")


### PR DESCRIPTION
Adds the resource timeout value to the Ranger service as a configuration on creation. 
![image](https://github.com/canonical/ranger-k8s-operator/assets/67629430/4c084443-2ed1-4e3a-bc74-6e3ffbe60c99)

By default this timeout is `1000` 1s. It's recommended in other implementations that this value could be as high as `10000` 10s : [Example 1](https://doris.apache.org/docs/admin-manual/auth/ranger/#:~:text=resource.lookup.timeout.value,10000%20%2C%20which%20is%2010%20seconds). And this patch: [Example 2](https://issues.apache.org/jira/browse/RANGER-1166)

This functionality enables the resource autocomplete. As currently with the `1000` value this is timing out and resulting in a `USER CANCELLED QUERY` result.
![image](https://github.com/canonical/ranger-k8s-operator/assets/67629430/0d1874fb-344f-4d12-a45f-5820c94ebfb3)
