### PR TITLE
CSS-10565: java home is set in the rock

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,9 +21,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.1/stable
+          juju-channel: 3.4/stable
           provider: microk8s
           microk8s-addons: "ingress storage dns rbac registry"
-          channel: 1.25-strict/stable
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e ${{ matrix.tox-environments }}

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -11,6 +11,6 @@ jobs:
     secrets: inherit
     with:
       integration-test-provider: microk8s
-      integration-test-provider-channel: 1.25-strict/stable
-      integration-test-juju-channel: 3.1/stable
+      integration-test-provider-channel: 1.28-strict/stable
+      integration-test-juju-channel: 3.4/stable
       integration-test-modules: '["test_charm"]'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ This project uses `tox` for managing test environments. There are some pre-confi
 that can be used for linting and formatting code when you're preparing contributions to the charm:
 
 ```shell
-tox run -e format        # update your code according to linting rules
+tox run -e fmt        # update your code according to linting rules
 tox run -e lint          # code style
 tox run -e unit          # unit tests
 tox run -e integration   # integration tests
-tox                      # runs 'format', 'lint', and 'unit' environments
+tox                      # runs 'fmt', 'lint', and 'unit' environments
 ```
 
 ## Set up your development environment

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,6 @@ from literals import (
     ADMIN_ENTRYPOINT,
     APP_NAME,
     APPLICATION_PORT,
-    JAVA_HOME,
     LOG_FILES,
     METRICS_PORT,
     RELATION_VALUES,
@@ -227,14 +226,14 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
             container: The application container.
         """
         command = [
-            f"{JAVA_HOME}/bin/keytool",
+            "keytool",
             "-storepass",
             "changeit",
             "-storepasswd",
             "-new",
             self._state.truststore_pwd,
             "-keystore",
-            f"{JAVA_HOME}/lib/security/cacerts",
+            "$JAVA_HOME/lib/security/cacerts",
         ]
         try:
             container.exec(command).wait_output()

--- a/src/literals.py
+++ b/src/literals.py
@@ -34,8 +34,6 @@ RELATION_VALUES = [
     "sync_ldap_url",
 ]
 
-JAVA_HOME = "/usr/lib/jvm/java-11-openjdk-amd64"
-
 # Observability literals
 METRICS_PORT = 6080
 LOG_FILES = ["/usr/lib/ranger/admin/ews/logs/ranger-admin-ranger-k8s-0-.log"]

--- a/src/relations/opensearch.py
+++ b/src/relations/opensearch.py
@@ -13,13 +13,7 @@ from ops.model import WaitingStatus
 from ops.pebble import ExecError
 from requests.auth import HTTPBasicAuth
 
-from literals import (
-    CERTIFICATE_NAME,
-    HEADERS,
-    INDEX_NAME,
-    JAVA_HOME,
-    OPENSEARCH_SCHEMA,
-)
+from literals import CERTIFICATE_NAME, HEADERS, INDEX_NAME, OPENSEARCH_SCHEMA
 from utils import log_event_handler
 
 logger = logging.getLogger(__name__)
@@ -97,10 +91,10 @@ class OpensearchRelationHandler(framework.Object):
         if not relation_broken and certificate:
             container.push("/opensearch.crt", certificate)
             command = [
-                f"{JAVA_HOME}/bin/keytool",
+                "keytool",
                 "-importcert",
                 "-keystore",
-                f"{JAVA_HOME}/lib/security/cacerts",
+                "$JAVA_HOME/lib/security/cacerts",
                 "-file",
                 "/opensearch.crt",
                 "-alias",
@@ -111,10 +105,10 @@ class OpensearchRelationHandler(framework.Object):
             ]
         else:
             command = [
-                f"{JAVA_HOME}/bin/keytool",
+                "keytool",
                 "-delete",
                 "-keystore",
-                f"{JAVA_HOME}/lib/security/cacerts",
+                "$JAVA_HOME/lib/security/cacerts",
                 "-alias",
                 CERTIFICATE_NAME,
                 "-storepass",

--- a/src/relations/provider.py
+++ b/src/relations/provider.py
@@ -193,13 +193,11 @@ class RangerProvider(Object):
         relation = self.charm.model.get_relation(
             self.relation_name, event.relation.id
         )
-        data = event.relation.data[event.app]
 
         if relation:
             relation.data[self.charm.app].update(
                 {
                     "policy_manager_url": self.charm.config["policy-mgr-url"],
-                    "service_name": data["name"],
                 }
             )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -58,8 +58,6 @@ USER_SECRET_CONTENT = {
     -----END CERTIFICATE-----""",
 }
 
-JAVA_HOME = "/usr/lib/jvm/java-11-openjdk-amd64"
-
 
 class MockService:
     """Defines functionality for the Ranger MockService."""
@@ -353,7 +351,6 @@ class TestCharm(TestCase):
         relation_data = harness.get_relation_data(rel_id, "ranger-k8s")
         expected_data = {
             "policy_manager_url": "http://ranger-k8s:6080",
-            "service_name": "trino-service",
         }
         self.assertEqual(relation_data, expected_data)
 
@@ -546,7 +543,7 @@ def simulate_admin_lifecycle(harness):
     container = harness.model.unit.get_container("ranger")
     harness.charm.on.ranger_pebble_ready.emit(container)
 
-    harness.handle_exec("ranger", [f"{JAVA_HOME}/bin/keytool"], result=0)
+    harness.handle_exec("ranger", ["keytool"], result=0)
 
     # Simulate database readiness.
     event = make_database_changed_event()

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,11 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
+  charm: TEST_FILE=test_charm.py
+  scaling: TEST_FILE=test_scaling.py
+  upgrades: TEST_FILE=test_upgrades.py
+  policy: TEST_FILE=test_policy.py
+  usersync: TEST_FILE=test_usersync.py
 passenv =
   PYTHONPATH
   CHARM_BUILD_DIR
@@ -27,7 +32,7 @@ passenv =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.1.3
     pytest-operator==0.29.0
     pytest-asyncio==0.21
@@ -35,65 +40,17 @@ deps =
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
 
-[testenv:integration-charm]
+[testenv:integration-{charm,scaling,upgrades,policy,usersync}]
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.1.3
     pytest-operator==0.22.0
     pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-   pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
-[testenv:integration-scaling]
-description = Run integration tests
-deps =
-    ipdb==0.13.9
-    juju==3.1.0.1
-    pytest==7.1.3
-    pytest-operator==0.22.0
-    pytest-asyncio==0.21
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
-[testenv:integration-upgrades]
-description = Run integration tests
-deps =
-    ipdb==0.13.9
-    juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
-    pytest-asyncio==0.21
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
-[testenv:integration-policy]
-description = Run integration tests
-deps =
-    ipdb==0.13.9
-    juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
-    pytest-asyncio==0.21
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest {[vars]tst_path}integration/test_policy.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
-[testenv:integration-usersync]
-description = Run integration tests
-deps =
-    ipdb==0.13.9
-    juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
-    pytest-asyncio==0.21
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest {[vars]tst_path}integration/test_usersync.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+   pytest {[vars]tst_path}integration/{env:TEST_FILE} -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
 
 [testenv:unit]
 description = Run tests


### PR DESCRIPTION
The PR removes references to JAVA_HOME, so we can update Java in the rock without updating the charm.

p.s: integration tests would fail until I update the rock. So the [PR](https://github.com/canonical/charmed-ranger-rock/pull/9) on the rock should be merged before.