### PR TITLE
Fix: use actual value of java_home to prevent misinterpretation as string

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -225,6 +225,11 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
         Args:
             container: The application container.
         """
+        out, _ = container.exec(
+            ["/bin/sh", "-c", "echo $JAVA_HOME"]
+        ).wait_output()
+        java_home = out.strip()
+
         command = [
             "keytool",
             "-storepass",
@@ -233,7 +238,7 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
             "-new",
             self._state.truststore_pwd,
             "-keystore",
-            "$JAVA_HOME/lib/security/cacerts",
+            f"{java_home}/lib/security/cacerts",
         ]
         try:
             container.exec(command).wait_output()

--- a/src/relations/opensearch.py
+++ b/src/relations/opensearch.py
@@ -87,6 +87,10 @@ class OpensearchRelationHandler(framework.Object):
 
         certificate = self.charm._state.opensearch_certificate
         truststore_pwd = self.charm._state.truststore_pwd
+        out, _ = container.exec(
+            ["/bin/sh", "-c", "echo $JAVA_HOME"]
+        ).wait_output()
+        java_home = out.strip()
 
         if not relation_broken and certificate:
             container.push("/opensearch.crt", certificate)
@@ -94,7 +98,7 @@ class OpensearchRelationHandler(framework.Object):
                 "keytool",
                 "-importcert",
                 "-keystore",
-                "$JAVA_HOME/lib/security/cacerts",
+                f"{java_home}/lib/security/cacerts",
                 "-file",
                 "/opensearch.crt",
                 "-alias",
@@ -108,7 +112,7 @@ class OpensearchRelationHandler(framework.Object):
                 "keytool",
                 "-delete",
                 "-keystore",
-                "$JAVA_HOME/lib/security/cacerts",
+                f"{java_home}/lib/security/cacerts",
                 "-alias",
                 CERTIFICATE_NAME,
                 "-storepass",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -519,6 +519,9 @@ def simulate_usersync_lifecycle(harness):
     harness.charm.on.ranger_pebble_ready.emit(container)
 
     harness.update_config({"charm-function": "usersync"})
+    harness.handle_exec(
+        "ranger", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
 
     # Simulate LDAP readiness.
     rel_id = harness.add_relation("ldap", "comsys-openldap-k8s")
@@ -543,6 +546,9 @@ def simulate_admin_lifecycle(harness):
     container = harness.model.unit.get_container("ranger")
     harness.charm.on.ranger_pebble_ready.emit(container)
 
+    harness.handle_exec(
+        "ranger", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
     harness.handle_exec("ranger", ["keytool"], result=0)
 
     # Simulate database readiness.

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ passenv =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.5.2.0
+    juju==3.5.2.1
     pytest==7.1.3
     pytest-operator==0.29.0
     pytest-asyncio==0.21
@@ -44,7 +44,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.5.2.0
+    juju==3.5.2.1
     pytest==7.1.3
     pytest-operator==0.22.0
     pytest-asyncio==0.21


### PR DESCRIPTION
The use of `$JAVA_HOME` directly in the `container.exec()` does not use the environment variable but rather interprets it as a string.