### PR TITLE
fix: make tls-secret-name optional for lego use

### DIFF
--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -37,7 +37,7 @@ class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
     ranger_admin_password: str
-    tls_secret_name: str
+    tls_secret_name: Optional[str]
     external_hostname: str
     sync_ldap_url: Optional[str]
     sync_ldap_bind_dn: Optional[str]


### PR DESCRIPTION
# Description

The charm makes `tls-secret-name` a mandatory configuration variable. That particular variable is used with `nginx-ingress-integrator` to supply a TLS certificate manually. However, the Lego charm can automate acquiring TLS certificates. Unfortunately, `tls-secret-name` currently cannot be left blank and using a dummy variable causes the ingress to get a default certificate that does not work.

This PR make `tls-secret-name` optional. This particular change has been tested via hacking the charm code manually and worked.

## Notes for Code Reviewers
The PR will be in draft until I can write proper tests. Unless we decide to forego tests for this change.