### PR TITLE
fix: handle pebble connection error in update-status hook

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,3 +7,5 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      self-hosted-runner: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--only-binary=pluggy # temporary workaround for charmcraft build errors
 apache-ranger == 0.0.11
 ops >= 2.2.0
 Jinja2 == 3.1.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,6 +196,9 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
 
         container = self.unit.get_container(self.name)
 
+        if not container.can_connect():
+            return
+
         check = container.get_check("up")
         if check.status != CheckStatus.UP:
             self.unit.status = MaintenanceStatus("Status check: DOWN")


### PR DESCRIPTION
This PR adds a container connectivity check before trying to access it at the occurrence of update_status hooks. This will help address the flakiness of Trino integration tests that deploy Ranger but go through a lot of container restarts due to resource pressure on self-hosted runners.