### PR TITLE
Fix/trino catalog cont on fail

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -33,6 +33,7 @@ from literals import (
     LOG_FILES,
     METRICS_PORT,
     RELATION_VALUES,
+    SUPPRESS_DEBUG_LOGS,
     USERSYNC_ENTRYPOINT,
 )
 from relations.ldap import LDAPRelationHandler
@@ -70,6 +71,7 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
             args: Ignore.
         """
         super().__init__(*args)
+        self._configure_logging()
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
         self.name = "ranger"
 
@@ -141,6 +143,13 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
             tls_secret_name=self.config["tls-secret-name"],
             backend_protocol="HTTP",
         )
+
+    @staticmethod
+    def _configure_logging():
+        """Suppress noisy third-party HTTP debug logs when enabled."""
+        if SUPPRESS_DEBUG_LOGS:
+            logging.getLogger("apache_ranger").setLevel(logging.WARNING)
+            logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     @log_event_handler(logger)
     def _on_install(self, event):
@@ -259,7 +268,7 @@ class RangerK8SCharm(TypedCharmBase[CharmConfig]):
                 return
             if e.stderr and "Warning" in e.stderr:
                 return
-            logger.debug(f"Unable to update truststore password {e.stderr}")
+            logger.debug("Unable to update truststore password %s", e.stderr)
 
     def _configure_ranger_admin(self, container):
         """Prepare Ranger Admin install.properties file.

--- a/src/literals.py
+++ b/src/literals.py
@@ -37,6 +37,7 @@ RELATION_VALUES = [
 # Observability literals
 METRICS_PORT = 6080
 LOG_FILES = ["/usr/lib/ranger/admin/ews/logs/ranger-admin-ranger-k8s-0-.log"]
+SUPPRESS_DEBUG_LOGS = True
 
 HEADERS = {
     "Content-Type": "application/json",

--- a/src/ranger_client.py
+++ b/src/ranger_client.py
@@ -50,22 +50,6 @@ class RangerAPIClient:
             auth: tuple of ``(username, password)`` for basic authentication.
         """
         self._client = RangerClient(url, auth)
-        self._client.client_http.session.hooks["response"].append(
-            RangerAPIClient._log_error_response
-        )
-
-    @staticmethod
-    def _log_error_response(response, *args, **kwargs):
-        """Log details of non-2xx HTTP responses for debugging."""
-        if not response.ok:
-            logger.debug(
-                "HTTP error: %s %s -> status=%s, headers=%s, body=%r",
-                response.request.method,
-                response.request.url,
-                response.status_code,
-                dict(response.headers),
-                response.text,
-            )
 
     def list_services_by_type(self, service_type: str) -> List[RangerService]:
         """List services filtered by type.

--- a/src/reconcile.py
+++ b/src/reconcile.py
@@ -358,7 +358,15 @@ class TrinoCatalogReconciler:
             self._ensure_roles(zone_name, existing_role_names)
             if zone_name not in existing_zone_names:
                 zone = _build_zone(zone_name, self._service_name)
-                self._client.create_zone(zone)
+                try:
+                    self._client.create_zone(zone)
+                except RangerAPIError as exc:
+                    logger.warning(
+                        "failed to create zone %s: %s",
+                        zone_name,
+                        exc.message,
+                    )
+                    continue
                 logger.info("created zone %s", zone_name)
                 self._purge_auto_policies(zone_name)
 
@@ -383,7 +391,14 @@ class TrinoCatalogReconciler:
         for role_name in _role_names(zone_name):
             if role_name not in existing_role_names:
                 role = RangerRole({"name": role_name})
-                self._client.create_role(role)
+                try:
+                    self._client.create_role(role)
+                except RangerAPIError as exc:
+                    logger.warning(
+                        "failed to create role %s: %s",
+                        role_name,
+                        exc.message,
+                    )
                 existing_role_names.add(role_name)
                 logger.info("created role %s", role_name)
 
@@ -397,11 +412,29 @@ class TrinoCatalogReconciler:
         Args:
             zone_name: the base zone / catalog name.
         """
-        auto_policies = self._client.list_policies(
-            zone_name, self._service_name
-        )
+        try:
+            auto_policies = self._client.list_policies(
+                zone_name, self._service_name
+            )
+        except RangerAPIError as exc:
+            logger.warning(
+                "failed to list auto-policies for zone %s, skipping purge: %s",
+                zone_name,
+                exc.message,
+            )
+            return
         for policy in auto_policies:
-            self._client.delete_policy_by_id(policy.id)
+            try:
+                self._client.delete_policy_by_id(policy.id)
+            except RangerAPIError as exc:
+                logger.warning(
+                    "failed to delete auto-policy %s (id=%s) from zone %s: %s",
+                    policy.name,
+                    policy.id,
+                    zone_name,
+                    exc.message,
+                )
+                continue
             logger.info(
                 "deleted auto-generated policy %s (id=%s) from zone %s",
                 policy.name,
@@ -415,7 +448,17 @@ class TrinoCatalogReconciler:
         Args:
             zone_name: the base zone / catalog name.
         """
-        policies = self._client.list_policies(zone_name, self._service_name)
+        try:
+            policies = self._client.list_policies(
+                zone_name, self._service_name
+            )
+        except RangerAPIError as exc:
+            logger.warning(
+                "failed to list policies for zone %s, skipping: %s",
+                zone_name,
+                exc.message,
+            )
+            return
         existing_by_name = {p.name: p for p in policies}
 
         for suffix, builder in _POLICY_BUILDERS.items():
@@ -423,13 +466,29 @@ class TrinoCatalogReconciler:
             desired = builder(zone_name, self._service_name)
 
             if policy_name not in existing_by_name:
-                self._client.create_policy(desired)
+                try:
+                    self._client.create_policy(desired)
+                except RangerAPIError as exc:
+                    logger.warning(
+                        "failed to create policy %s: %s",
+                        policy_name,
+                        exc.message,
+                    )
+                    continue
                 logger.info("created policy %s", policy_name)
             else:
                 existing = existing_by_name[policy_name]
                 if self._policy_needs_update(existing, desired):
                     desired.id = existing.id
-                    self._client.update_policy(existing.id, desired)
+                    try:
+                        self._client.update_policy(existing.id, desired)
+                    except RangerAPIError as exc:
+                        logger.warning(
+                            "failed to update policy %s: %s",
+                            policy_name,
+                            exc.message,
+                        )
+                        continue
                     logger.info("updated policy %s", policy_name)
 
     def _cleanup_zone(self, zone_name: str) -> None:
@@ -440,7 +499,17 @@ class TrinoCatalogReconciler:
         Args:
             zone_name: the zone to potentially remove.
         """
-        policies = self._client.list_policies(zone_name, self._service_name)
+        try:
+            policies = self._client.list_policies(
+                zone_name, self._service_name
+            )
+        except RangerAPIError as exc:
+            logger.warning(
+                "failed to list policies for zone %s, skipping cleanup: %s",
+                zone_name,
+                exc.message,
+            )
+            return
         default_names = _default_policy_names(zone_name)
 
         for policy in policies:
@@ -452,17 +521,26 @@ class TrinoCatalogReconciler:
                 )
                 return
 
-        self._client.delete_zone(zone_name)
+        try:
+            self._client.delete_zone(zone_name)
+        except RangerAPIError as exc:
+            logger.warning(
+                "failed to delete stale zone %s: %s",
+                zone_name,
+                exc.message,
+            )
+            return
         logger.info("deleted stale zone %s", zone_name)
 
         for role_name in _role_names(zone_name):
             try:
                 self._client.delete_role(role_name)
                 logger.info("deleted stale role %s", role_name)
-            except RangerAPIError:
+            except RangerAPIError as exc:
                 logger.warning(
-                    "could not delete role %s, it may not exist",
+                    "could not delete role %s: %s",
                     role_name,
+                    exc.message,
                 )
 
     @staticmethod

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -139,6 +139,13 @@ class TestCharm(TestCase):
         initial_plan = harness.get_container_pebble_plan("ranger").to_dict()
         self.assertEqual(initial_plan, {})
 
+    def test_suppress_debug_logs_configured(self):
+        """Third-party loggers are set to WARNING when SUPPRESS_DEBUG_LOGS is enabled."""
+        apache_ranger_logger = logging.getLogger("apache_ranger")
+        urllib3_logger = logging.getLogger("urllib3")
+        self.assertEqual(apache_ranger_logger.level, logging.WARNING)
+        self.assertEqual(urllib3_logger.level, logging.WARNING)
+
     def test_waiting_on_peer_relation_not_ready(self):
         """The charm is blocked without a peer relation."""
         harness = self.harness


### PR DESCRIPTION
# What
Previous implementation of the Trino-Ranger was functional on a clean slate but the staging deployment has shown that it fails to reconcile with trying to create already existing resources.

This PR addresses that issue by skipping actions on errors and logging the cause.
* If the error was due to the resource already existing, it should not repeat.
* If the error was something else, it will retry on future `update_status` hooks.

I also touched on the logs to reduce noise and eliminate leaks.